### PR TITLE
CDAP-19501: Create/Update stream in validateOnly mode during assessment

### DIFF
--- a/src/main/java/io/cdap/delta/datastream/DatastreamDeltaSource.java
+++ b/src/main/java/io/cdap/delta/datastream/DatastreamDeltaSource.java
@@ -93,7 +93,7 @@ public class DatastreamDeltaSource implements DeltaSource {
     String streamPath = Utils.buildStreamPath(parentPath, config.getStreamId());
     Stream.Builder streamBuilder = Utils.getStream(datastream, streamPath, LOGGER).toBuilder();
     Utils.addToAllowList(streamBuilder, context.getAllTables());
-    Utils.updateAllowlist(datastream, streamBuilder.build(), LOGGER);
+    Utils.updateAllowlist(datastream, streamBuilder.build(), false, LOGGER);
   }
 
   @Override

--- a/src/main/java/io/cdap/delta/datastream/util/Utils.java
+++ b/src/main/java/io/cdap/delta/datastream/util/Utils.java
@@ -731,15 +731,19 @@ public final class Utils {
    *
    * @param datastream Datastream client
    * @param stream     the builder of the stream to be updated
+   * @param validateOnly only validate the changes to the stream
    * @param logger     the logger
    * @return the updated stream
    */
-  public static Stream updateAllowlist(DatastreamClient datastream, Stream stream, Logger logger) {
+  public static Stream updateAllowlist(DatastreamClient datastream, Stream stream, boolean validateOnly,
+                                        Logger logger) {
     Stream.Builder streamBuilder = Stream.newBuilder().setName(stream.getName());
     streamBuilder.getSourceConfigBuilder().getOracleSourceConfigBuilder()
       .setAllowlist(stream.getSourceConfig().getOracleSourceConfig().getAllowlist());
-    return updateStream(datastream, UpdateStreamRequest.newBuilder().setStream(streamBuilder)
-      .setUpdateMask(FieldMask.newBuilder().addPaths(FIELD_ALLOWLIST)).build(), logger);
+    UpdateStreamRequest request = UpdateStreamRequest.newBuilder().setStream(streamBuilder)
+            .setUpdateMask(FieldMask.newBuilder().addPaths(FIELD_ALLOWLIST))
+            .setValidateOnly(validateOnly).build();
+    return updateStream(datastream, request, logger);
   }
 
   /**

--- a/src/test/java/com/google/cloud/datastream/v1alpha1/DatastreamClientTest.java
+++ b/src/test/java/com/google/cloud/datastream/v1alpha1/DatastreamClientTest.java
@@ -252,9 +252,12 @@ public class DatastreamClientTest {
           .setRejectlist(OracleRdbms.getDefaultInstance())))
       .setBackfillAll(Stream.BackfillAllStrategy.getDefaultInstance());
 
-    //TODO set validate_only to true when it works
     OperationFuture<Stream, OperationMetadata> streamValidationOperation = datastream.createStreamAsync(
-      CreateStreamRequest.newBuilder().setParent(parent).setStream(streamBuilder).setStreamId(streamName).build());
+      CreateStreamRequest.newBuilder().setParent(parent)
+              .setStream(streamBuilder)
+              .setStreamId(streamName)
+              .setValidateOnly(true)
+              .build());
     ExecutionException exception = assertThrows(ExecutionException.class, () -> streamValidationOperation.get());
     assertTrue(exception.getCause() instanceof FailedPreconditionException);
     ValidationResult validationResult = streamValidationOperation.getMetadata().get().getValidationResult();

--- a/src/test/java/io/cdap/delta/datastream/BaseIntegrationTestCase.java
+++ b/src/test/java/io/cdap/delta/datastream/BaseIntegrationTestCase.java
@@ -143,11 +143,14 @@ public class BaseIntegrationTestCase {
       .collect(Collectors.toSet());
   }
 
-  protected DatastreamDeltaSource createDeltaSource(boolean usingExisting) throws Exception {
+  protected DatastreamDeltaSource createDeltaSource(boolean usingExisting) {
     DatastreamConfig config = buildDatastreamConfig(usingExisting);
     DatastreamDeltaSource deltaSource = new DatastreamDeltaSource(config);
     return deltaSource;
   }
 
+  protected DatastreamDeltaSource createDeltaSource(DatastreamConfig config) {
+    return new DatastreamDeltaSource(config);
+  }
 }
 


### PR DESCRIPTION
1. Set validateOnly=true for create/update datastream during assessment 
2. Remove cleanup code
3. Added test for assessment with invalid database credentials