### PR TITLE
CDAP-19591 Source plugin configuration to accept GCS bucket location for datastream result

### DIFF
--- a/docs/OracleDatastream-cdcSource.md
+++ b/docs/OracleDatastream-cdcSource.md
@@ -93,6 +93,9 @@ Plugin properties
 
 **GCS Service Account Key:** The service account key for the service account that will be used as the identity to access GCS. Datastream will write the change stream to the GCS bucket you specified as the `GCS Bucket` property of this plugin. This service account will be used as the identity to get and create (if you want this plugin to create a new bucket) the bucket and read Datastream result from the bucket. It will default to the content of the file referred by the system property `GOOGLE_APPLICATION_CREDENTIALS` for CDAP and Data Fusion Service Account for Data Fusion. 
 
+**GCS Bucket Location:** The location of GCS (Google Cloud Storage) bucket that Datastream will write its output to. A complete list of available locations can be found at
+https://cloud.google.com/bigquery/docs/locations. This value is ignored if an existing GCS bucket is specified.
+
 **GCS Bucket:** The GCS (Google Cloud Storage) bucket that Datastream will write its output to. If the bucket you provide doesn't exist or you leave it as empty, this plugin will create a new one in the `Project` you specified in this plugin. 
 
 **Path Prefix:** The GCS (Google Cloud Storage) path prefix in the bucket that Datastream will write its output to. This prefix will be prefixed to the Datastream output path. It's usually used when you want Datastream to write its output to an existing bucket and you want to easily differentiate it from other existing GCS files by its path prefix.  

--- a/src/main/java/io/cdap/delta/datastream/DatastreamConfig.java
+++ b/src/main/java/io/cdap/delta/datastream/DatastreamConfig.java
@@ -129,6 +129,10 @@ public class DatastreamConfig extends PluginConfig {
   // only required when connectivity method is  "Private connectivity (VPC peering)"
   private String privateConnectionName;
 
+  @Nullable
+  @Description("The location of the GCS bucket where Datastream will write its output to." +
+          "This value is ignored if an existing GCS bucket is specified")
+  protected String gcsBucketLocation;
 
   @Nullable
   @Description("The GCS bucket that Datastream can write its output to. By default replicator " +
@@ -250,6 +254,10 @@ public class DatastreamConfig extends PluginConfig {
     return privateConnectionName;
   }
 
+  @Nullable
+  public String getGcsBucketLocation() {
+    return gcsBucketLocation;
+  }
 
   @Nullable
   public String getGcsBucket() {
@@ -300,12 +308,12 @@ public class DatastreamConfig extends PluginConfig {
   }
 
   public DatastreamConfig(boolean usingExistingStream, @Nullable String host, @Nullable Integer port,
-    @Nullable String user, @Nullable String password, @Nullable String sid, @Nullable String region,
-    @Nullable String connectivityMethod, @Nullable String sshHost, @Nullable Integer sshPort, @Nullable String sshUser,
-    @Nullable String sshAuthenticationMethod, @Nullable String sshPassword, @Nullable String sshPrivateKey,
-    @Nullable String gcsBucket, @Nullable String gcsPathPrefix, @Nullable String gcsServiceAccountKey,
-    @Nullable String dsServiceAccountKey, @Nullable String streamId, @Nullable String project,
-    @Nullable String privateConnectionName) {
+                          @Nullable String user, @Nullable String password, @Nullable String sid, @Nullable String region,
+                          @Nullable String connectivityMethod, @Nullable String sshHost, @Nullable Integer sshPort, @Nullable String sshUser,
+                          @Nullable String sshAuthenticationMethod, @Nullable String sshPassword, @Nullable String sshPrivateKey,
+                          @Nullable String gcsBucketLocation, @Nullable String gcsBucket, @Nullable String gcsPathPrefix, @Nullable String gcsServiceAccountKey,
+                          @Nullable String dsServiceAccountKey, @Nullable String streamId, @Nullable String project,
+                          @Nullable String privateConnectionName) {
     this.usingExistingStream = usingExistingStream;
     this.host = host;
     this.port = port;
@@ -327,6 +335,7 @@ public class DatastreamConfig extends PluginConfig {
     this.streamId = streamId;
     this.project = project;
     this.privateConnectionName = privateConnectionName;
+    this.gcsBucketLocation = gcsBucketLocation;
     validate();
   }
 

--- a/src/main/java/io/cdap/delta/datastream/DatastreamDeltaSource.java
+++ b/src/main/java/io/cdap/delta/datastream/DatastreamDeltaSource.java
@@ -151,7 +151,7 @@ public class DatastreamDeltaSource implements DeltaSource {
       // check whether GCS Bucket exists first
       String bucketName = config.getGcsBucket();
       // If user doesn't provide bucketName, we assign one based on run id
-      if (bucketName == null || bucketName.isEmpty()) {
+      if (bucketName == null || bucketName.trim().isEmpty()) {
         bucketName = Utils.buildBucketName(context.getRunId());
       }
       Utils.createBucketIfNotExisting(storage, bucketName, config.getGcsBucketLocation());

--- a/src/main/java/io/cdap/delta/datastream/DatastreamDeltaSource.java
+++ b/src/main/java/io/cdap/delta/datastream/DatastreamDeltaSource.java
@@ -151,10 +151,10 @@ public class DatastreamDeltaSource implements DeltaSource {
       // check whether GCS Bucket exists first
       String bucketName = config.getGcsBucket();
       // If user doesn't provide bucketName, we assign one based on run id
-      if (bucketName == null) {
+      if (bucketName == null || bucketName.isEmpty()) {
         bucketName = Utils.buildBucketName(context.getRunId());
       }
-      Utils.createBucketIfNotExisting(storage, bucketName);
+      Utils.createBucketIfNotExisting(storage, bucketName, config.getGcsBucketLocation());
 
       // create the gcs connection profile
       createConnectionProfileRequest =

--- a/src/main/java/io/cdap/delta/datastream/DatastreamTableAssessor.java
+++ b/src/main/java/io/cdap/delta/datastream/DatastreamTableAssessor.java
@@ -233,7 +233,7 @@ public class DatastreamTableAssessor implements TableAssessor<TableDetail> {
         }
         // create corresponding GCS bucket
         try {
-          bucketCreated = Utils.createBucketIfNotExisting(storage, bucketName);
+          bucketCreated = Utils.createBucketIfNotExisting(storage, bucketName, conf.getGcsBucketLocation());
         } catch (Exception e) {
           throw new RuntimeException(String.format("Fail to assess replicator pipeline due to failure of creating GCS" +
                                                      " Bucket:\n%s.", e.getLocalizedMessage()), e);

--- a/src/main/java/io/cdap/delta/datastream/util/Utils.java
+++ b/src/main/java/io/cdap/delta/datastream/util/Utils.java
@@ -833,7 +833,13 @@ public final class Utils {
                           ((StorageException) t).getCode() == GCS_ERROR_CODE_CONFLICT ||
                           ((StorageException) t).getCode() == GCS_ERROR_CODE_INVALID_REQUEST)
                       ))
-        .run(() -> storage.create(BucketInfo.newBuilder(bucketName).setLocation(location).build()));
+        .run(() -> {
+          BucketInfo.Builder builder = BucketInfo.newBuilder(bucketName);
+          if(location != null && !location.trim().isEmpty()){
+            builder.setLocation(location);
+          }
+          storage.create(builder.build());
+        });
     } catch (StorageException se) {
       // It is possible that in multiple worker instances scenario
       // bucket is created by another worker instance after this worker instance

--- a/src/main/java/io/cdap/delta/datastream/util/Utils.java
+++ b/src/main/java/io/cdap/delta/datastream/util/Utils.java
@@ -822,9 +822,10 @@ public final class Utils {
    * Create a GCS bucket if it doesn't exist
    * @param storage the GCS client
    * @param bucketName the name of the bucket to be created
+   * @param location location where bucket will be created
    * @return whether the GCS bucket is newly created by this method
    */
-  public static boolean createBucketIfNotExisting(Storage storage, String bucketName) throws IOException {
+  public static boolean createBucketIfNotExisting(Storage storage, String bucketName, String location) throws IOException {
     // create corresponding GCS bucket
     try {
       Failsafe.with(createRetryPolicy()
@@ -832,7 +833,7 @@ public final class Utils {
                           ((StorageException) t).getCode() == GCS_ERROR_CODE_CONFLICT ||
                           ((StorageException) t).getCode() == GCS_ERROR_CODE_INVALID_REQUEST)
                       ))
-        .run(() -> storage.create(BucketInfo.newBuilder(bucketName).build()));
+        .run(() -> storage.create(BucketInfo.newBuilder(bucketName).setLocation(location).build()));
     } catch (StorageException se) {
       // It is possible that in multiple worker instances scenario
       // bucket is created by another worker instance after this worker instance

--- a/src/test/java/io/cdap/delta/datastream/BaseIntegrationTestCase.java
+++ b/src/test/java/io/cdap/delta/datastream/BaseIntegrationTestCase.java
@@ -134,7 +134,7 @@ public class BaseIntegrationTestCase {
   protected DatastreamConfig buildDatastreamConfig(boolean usingExisting) {
     return new DatastreamConfig(usingExisting, oracleHost, oraclePort, oracleUser, oraclePassword, oracleDb,
       serviceLocation, DatastreamConfig.CONNECTIVITY_METHOD_IP_ALLOWLISTING, null, null, null, null, null, null,
-      gcsBucket, null, serviceAccountKey, serviceAccountKey, streamId, project, null);
+            null, gcsBucket, null, serviceAccountKey, serviceAccountKey, streamId, project, null);
   }
 
   protected Set<SourceTable> getSourceTables() {

--- a/src/test/java/io/cdap/delta/datastream/DatastreamAsessorTest.java
+++ b/src/test/java/io/cdap/delta/datastream/DatastreamAsessorTest.java
@@ -64,7 +64,7 @@ public class DatastreamAsessorTest extends BaseIntegrationTestCase {
     DatastreamConfig datastreamConfig = new DatastreamConfig(false, oracleHost, oraclePort,
             invalidOracleUser, oraclePassword, oracleDb, serviceLocation,
             DatastreamConfig.CONNECTIVITY_METHOD_IP_ALLOWLISTING, null, null, null, null, null, null,
-            gcsBucket, null, serviceAccountKey, serviceAccountKey, streamId, project, null);
+            null, gcsBucket, null, serviceAccountKey, serviceAccountKey, streamId, project, null);
     DatastreamDeltaSource deltaSource = createDeltaSource(datastreamConfig);
     List<SourceTable> tables = new ArrayList<>(getSourceTables());
     try (TableAssessor<TableDetail> assessor = deltaSource.createTableAssessor(null, tables)) {

--- a/src/test/java/io/cdap/delta/datastream/DatastreamConfigTest.java
+++ b/src/test/java/io/cdap/delta/datastream/DatastreamConfigTest.java
@@ -35,7 +35,7 @@ class DatastreamConfigTest {
   void testDefaultValues() {
     DatastreamConfig config =
       new DatastreamConfig(false, "hostname", null, "user", "password", null, null, null, null, null, null,
-                           null, null, null, null, null, null, null, null, null, null);
+                           null, null, null, null, null, null, null, null, null, null, null);
 
     assertFalse(config.isUsingExistingStream());
     assertEquals("hostname", config.getHost());
@@ -49,6 +49,7 @@ class DatastreamConfigTest {
     assertNull(config.getSshAuthenticationMethod());
     assertNull(config.getStreamId());
     assertNull(config.getGcsBucket());
+    assertNull(config.getGcsBucketLocation());
     assertEquals("/", config.getGcsPathPrefix());
     assertNotNull(config.getDatastreamCredentials());
     assertNotNull(config.getGcsCredentials());
@@ -58,7 +59,7 @@ class DatastreamConfigTest {
     // forward ssh tunnel as connectivity method
     config = new DatastreamConfig(false, "hostname", null, "user", "password", null, null,
                                   DatastreamConfig.CONNECTIVITY_METHOD_FORWARD_SSH_TUNNEL,
-                                  "sshHost", null, "sshUser", null, null, "sshPrivateKey", "bucket",
+                                  "sshHost", null, "sshUser", null, null, "sshPrivateKey", "us", "bucket",
                                   "prefix", "gcs-key", "datastream-key", null, "project", null);
     assertEquals("sshHost", config.getSshHost());
     assertEquals(DatastreamConfig.DEFAULT_SSH_PORT, config.getSshPort());
@@ -69,6 +70,7 @@ class DatastreamConfigTest {
     assertNull(config.getSshPassword());
     assertNull(config.getPrivateConnectionName());
     assertEquals("bucket", config.getGcsBucket());
+    assertEquals("us", config.getGcsBucketLocation());
     assertEquals("/prefix", config.getGcsPathPrefix());
     DatastreamConfig conf = config;
     assertThrows(IllegalArgumentException.class, () -> conf.getDatastreamCredentials());
@@ -83,7 +85,7 @@ class DatastreamConfigTest {
     // as connectivity method.
     new DatastreamConfig(false, "hostname", null, "user", "password", null, null,
                          DatastreamConfig.CONNECTIVITY_METHOD_IP_ALLOWLISTING, null, null, null,
-                         null, null, null, null, null, null, null, null, null, null).validate();
+                         null, null, null, null, null, null, null, null, null, null, null).validate();
 
     // sshPassowrd can be null if forward ssh tunnel is selected as connectivity method
     // and private/public key pair is selected as authentication method
@@ -91,7 +93,7 @@ class DatastreamConfigTest {
                                                    DatastreamConfig.CONNECTIVITY_METHOD_FORWARD_SSH_TUNNEL,
                                                    "sshHost", null, "sshUser",
                                                    DatastreamConfig.AUTHENTICATION_METHOD_PRIVATE_PUBLIC_KEY,
-                                                   null, "sshPrivateKey", null, null, null, null, null, null, null);
+                                                   null, "sshPrivateKey", null, null, null, null, null, null, null, null);
     config.validate();
     // host should not be null
     Field field = DatastreamConfig.class.getDeclaredField("host");

--- a/widgets/OracleDatastream-cdcSource.json
+++ b/widgets/OracleDatastream-cdcSource.json
@@ -198,6 +198,14 @@
           }
         },
         {
+          "name": "gcsBucketLocation",
+          "label": "GCS Bucket Location",
+          "widget-type": "textbox",
+          "widget-attributes": {
+            "default": "us"
+          }
+        },
+        {
           "name": "gcsBucket",
           "label": "GCS Bucket",
           "widget-type": "textbox"


### PR DESCRIPTION
Enable user to specify the location where GCS bucket for Datastream results will be created. This is similar to how the GCS bucket location for staging bucket is accepted in https://github.com/data-integrations/bigquery-delta-plugins/