### PR TITLE
CDAP-19596: Check stream state is valid during handling for AbortException

### DIFF
--- a/src/main/java/io/cdap/delta/datastream/util/Utils.java
+++ b/src/main/java/io/cdap/delta/datastream/util/Utils.java
@@ -54,6 +54,7 @@ import com.google.cloud.storage.BucketInfo;
 import com.google.cloud.storage.Storage;
 import com.google.cloud.storage.StorageException;
 import com.google.common.base.Joiner;
+import com.google.common.collect.ImmutableSet;
 import com.google.protobuf.Duration;
 import com.google.protobuf.Empty;
 import com.google.protobuf.FieldMask;
@@ -73,6 +74,7 @@ import java.io.IOException;
 import java.sql.SQLType;
 import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -688,7 +690,7 @@ public final class Utils {
    * @return the started stream
    */
   public static Stream startStream(DatastreamClient datastream, Stream stream, Logger logger) {
-    return updateStreamState(datastream, stream.getName(), Stream.State.RUNNING, logger);
+    return updateStreamState(datastream, stream.getName(), Stream.State.RUNNING, Stream.State.STARTING, logger);
   }
 
   /**
@@ -700,11 +702,11 @@ public final class Utils {
    * @return the paused stream
    */
   public static Stream pauseStream(DatastreamClient datastream, Stream stream, Logger logger) {
-    return updateStreamState(datastream, stream.getName(), Stream.State.PAUSED, logger);
+    return updateStreamState(datastream, stream.getName(), Stream.State.PAUSED, Stream.State.DRAINING, logger);
   }
 
   private static Stream updateStreamState(DatastreamClient datastream, String streamName, Stream.State state,
-    Logger logger) {
+                                          Stream.State transitionState, Logger logger) {
     Stream.Builder streamBuilder = Stream.newBuilder().setName(streamName).setState(state);
     FieldMask.Builder fieldMaskBuilder = FieldMask.newBuilder().addPaths(FIELD_STATE);
 
@@ -713,14 +715,26 @@ public final class Utils {
     // a predicate that indicate that we try to start/pause a stream when it is already in the progress of
     // starting/pausing
     Predicate<? extends Throwable> streamBeingChangedPredicate = t -> t.getCause() instanceof ExecutionException &&
-      // If there is already an operation queued, an AbortedException will be thrown
-      t.getCause().getCause() instanceof AbortedException;
+            // If there is already an operation queued, an AbortedException will be thrown
+            // Check if the stream is in one of transition or target state
+            (t.getCause().getCause() instanceof AbortedException) &&
+            streamStateIn(datastream, streamName, ImmutableSet.of(state, transitionState), logger);
 
     return Failsafe.with(
-      // fall back to get stream until stream state reaches target state
-      Fallback.of(() -> getStreamUntilStateEquals(datastream, state, streamName, logger))
-        .handleIf(streamBeingChangedPredicate)).get(() -> updateStream(datastream,
-      UpdateStreamRequest.newBuilder().setStream(streamBuilder).setUpdateMask(fieldMaskBuilder).build(), logger));
+            // fall back to get stream until stream state reaches target state
+            Fallback.of(() -> getStreamUntilStateEquals(datastream, state, streamName, logger))
+                    .handleIf(streamBeingChangedPredicate)).get(() -> updateStream(datastream,
+            UpdateStreamRequest.newBuilder().setStream(streamBuilder).setUpdateMask(fieldMaskBuilder).build(), logger));
+  }
+
+  private static boolean streamStateIn(DatastreamClient datastream, String streamName, Set<Stream.State> validStates,
+                                       Logger logger) {
+    Stream stream = getStream(datastream, streamName, logger);
+    boolean isStateValid = validStates.contains(stream.getState());
+    if (!isStateValid) {
+      logger.error("Stream {} is not in valid state {}", streamName, stream.getState());
+    }
+    return isStateValid;
   }
 
   /**


### PR DESCRIPTION
Datastream control plane can throw `AbortException` when multiple workers try to start/pause stream concurrently, with error message "queue length exceeded" but does not provide any other error code. 

Current handling for this exception is to just poll the stream state and check if it changes to desired state (e.g. `RUNNING`) But this should only be done in case the stream is in the transition state (e.g. `STARTING`) and not for other states (say `FAILED`). 