### PR TITLE
Limit discover connection profile to table level when listing tables …

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -156,6 +156,12 @@
       <version>0.25.0</version>
       <scope>compile</scope>
     </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-inline</artifactId>
+      <version>2.24.0</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/pom.xml
+++ b/pom.xml
@@ -159,7 +159,7 @@
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-inline</artifactId>
-      <version>2.24.0</version>
+      <version>4.11.0</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -65,6 +65,29 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
   </properties>
 
+  <repositories>
+    <repository>
+      <id>sonatype</id>
+      <url>https://oss.sonatype.org/content/groups/public</url>
+      <releases>
+        <enabled>true</enabled>
+      </releases>
+      <snapshots>
+        <enabled>false</enabled>
+      </snapshots>
+    </repository>
+    <repository>
+      <id>sonatype-snapshots</id>
+      <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+      <releases>
+        <enabled>false</enabled>
+      </releases>
+      <snapshots>
+        <enabled>true</enabled>
+      </snapshots>
+    </repository>
+  </repositories>
+
   <distributionManagement>
     <repository>
       <id>sonatype.release</id>

--- a/src/main/java/io/cdap/delta/datastream/DatastreamTableAssessor.java
+++ b/src/main/java/io/cdap/delta/datastream/DatastreamTableAssessor.java
@@ -315,6 +315,8 @@ public class DatastreamTableAssessor implements TableAssessor<TableDetail> {
                                                  "operation metadata:\n%s", e.getLocalizedMessage()), e);
     }
 
+    LOGGER.error("Stream validation failed : {}", metadata);
+
     List<Problem> connectivityIssues = new ArrayList<>();
     List<Problem> missingFeatures = new ArrayList<>();
     for (Validation validation : metadata.getValidationResult().getValidationsList()) {

--- a/src/main/java/io/cdap/delta/datastream/DatastreamTableRegistry.java
+++ b/src/main/java/io/cdap/delta/datastream/DatastreamTableRegistry.java
@@ -191,6 +191,11 @@ public class DatastreamTableRegistry implements TableRegistry {
 
   private DiscoverConnectionProfileRequest.Builder buildDiscoverConnectionProfileRequest(
     String sourceConnectionProfileName) throws IOException {
+    //Hierarchy Depth specifies the number of levels below the current level to be
+    //retrieved (Levels : db -> schema -> table -> columns).
+    //While listing tables,next two levels(schema.table) from db(current level) have to be retrieved.
+    //While displaying table details, only single level(columns) from tables is needed.
+    //Hence, hierarchy depth is set to 2.
     DiscoverConnectionProfileRequest.Builder request =
       DiscoverConnectionProfileRequest.newBuilder().setParent(parentPath).setHierarchyDepth(2);
 

--- a/src/main/java/io/cdap/delta/datastream/DatastreamTableRegistry.java
+++ b/src/main/java/io/cdap/delta/datastream/DatastreamTableRegistry.java
@@ -192,7 +192,7 @@ public class DatastreamTableRegistry implements TableRegistry {
   private DiscoverConnectionProfileRequest.Builder buildDiscoverConnectionProfileRequest(
     String sourceConnectionProfileName) throws IOException {
     DiscoverConnectionProfileRequest.Builder request =
-      DiscoverConnectionProfileRequest.newBuilder().setParent(parentPath).setFullHierarchy(true);
+      DiscoverConnectionProfileRequest.newBuilder().setParent(parentPath).setHierarchyDepth(2);
 
     if (sourceConnectionProfileName == null || sourceConnectionProfileName.isEmpty()) {
       return request.setConnectionProfile(Utils.buildOracleConnectionProfile(parentPath, "", config));

--- a/src/test/java/io/cdap/delta/datastream/DatastreamTableRegistryIntegrationTest.java
+++ b/src/test/java/io/cdap/delta/datastream/DatastreamTableRegistryIntegrationTest.java
@@ -31,7 +31,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
-class DatastreamTableRegistryTest extends BaseIntegrationTestCase {
+class DatastreamTableRegistryIntegrationTest extends BaseIntegrationTestCase {
 
   @Test
   public void testListDescribeTableNew() throws Exception {

--- a/src/test/java/io/cdap/delta/datastream/DatastreamTableRegistryTest.java
+++ b/src/test/java/io/cdap/delta/datastream/DatastreamTableRegistryTest.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright © 2023 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.delta.datastream;
+
+import com.google.cloud.datastream.v1.DatastreamClient;
+import com.google.cloud.datastream.v1.DiscoverConnectionProfileRequest;
+import com.google.cloud.datastream.v1.DiscoverConnectionProfileResponse;
+import com.google.cloud.datastream.v1.OracleRdbms;
+import com.google.cloud.datastream.v1.OracleSchema;
+import com.google.cloud.datastream.v1.OracleTable;
+import io.cdap.delta.api.assessment.TableList;
+import io.cdap.delta.api.assessment.TableSummary;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+public class DatastreamTableRegistryTest {
+  @Test
+  public void testListTable() throws Exception {
+    DatastreamConfig datastreamConfig = Mockito.mock(DatastreamConfig.class);
+    Mockito.when(datastreamConfig.isUsingExistingStream()).thenReturn(false);
+    Mockito.when(datastreamConfig.getSid()).thenReturn("sid");
+    Mockito.when(datastreamConfig.getHost()).thenReturn("host");
+    Mockito.when(datastreamConfig.getUser()).thenReturn("user");
+    Mockito.when(datastreamConfig.getPassword()).thenReturn("password");
+    Mockito.when(datastreamConfig.getConnectivityMethod()).thenReturn("ip-allowlisting");
+
+    DiscoverConnectionProfileResponse response = Mockito.mock(DiscoverConnectionProfileResponse.class);
+
+    OracleTable table = Mockito.mock(OracleTable.class);
+    Mockito.when(table.getTable()).thenReturn("table");
+    Mockito.when(table.getOracleColumnsCount()).thenReturn(2);
+
+    OracleSchema schema = Mockito.mock(OracleSchema.class);
+    Mockito.when(schema.getSchema()).thenReturn("schema");
+    Mockito.when(schema.getOracleTablesList()).thenReturn(Arrays.asList(table));
+
+    OracleRdbms oracleRdbms = Mockito.mock(OracleRdbms.class);
+    Mockito.when(response.getOracleRdbms()).thenReturn(oracleRdbms);
+    Mockito.when(oracleRdbms.getOracleSchemasList()).thenReturn(Arrays.asList(schema));
+
+    DatastreamClient datastreamClient = Mockito.mock(DatastreamClient.class);
+    Mockito.when(datastreamClient.discoverConnectionProfile(Mockito.any())).thenReturn(response);
+
+    DatastreamTableRegistry datastreamTableRegistry = new DatastreamTableRegistry(datastreamConfig, datastreamClient);
+    TableList tableList = datastreamTableRegistry.listTables();
+
+    assertNotNull(tableList);
+    List<TableSummary> tables = tableList.getTables();
+    assertNotNull(tables);
+    assertFalse(tables.isEmpty());
+    System.out.println("table counts:" + tables.size());
+
+    //verify hierarchy depth set to 2
+    ArgumentCaptor<DiscoverConnectionProfileRequest> captor = ArgumentCaptor.forClass(
+      DiscoverConnectionProfileRequest.class);
+    Mockito.verify(datastreamClient).discoverConnectionProfile(captor.capture());
+    assertEquals(captor.getValue().getHierarchyDepth(), 2);
+  }
+}

--- a/src/test/java/io/cdap/delta/datastream/DatastreamTableRegistryTest.java
+++ b/src/test/java/io/cdap/delta/datastream/DatastreamTableRegistryTest.java
@@ -70,12 +70,17 @@ public class DatastreamTableRegistryTest {
     List<TableSummary> tables = tableList.getTables();
     assertNotNull(tables);
     assertFalse(tables.isEmpty());
-    System.out.println("table counts:" + tables.size());
-
+    assertEquals(1, tables.size());
+    TableSummary table1 = tables.get(0);
+    assertNotNull(table1.getSchema());
+    assertNotNull(table1.getTable());
+    assertEquals("schema", table1.getSchema());
+    assertEquals("table", table1.getTable());
+    
     //verify hierarchy depth set to 2
     ArgumentCaptor<DiscoverConnectionProfileRequest> captor = ArgumentCaptor.forClass(
       DiscoverConnectionProfileRequest.class);
     Mockito.verify(datastreamClient).discoverConnectionProfile(captor.capture());
-    assertEquals(captor.getValue().getHierarchyDepth(), 2);
+    assertEquals(2, captor.getValue().getHierarchyDepth());
   }
 }

--- a/src/test/java/io/cdap/delta/datastream/DatastreamTableRegistryTest.java
+++ b/src/test/java/io/cdap/delta/datastream/DatastreamTableRegistryTest.java
@@ -69,11 +69,8 @@ public class DatastreamTableRegistryTest {
     assertNotNull(tableList);
     List<TableSummary> tables = tableList.getTables();
     assertNotNull(tables);
-    assertFalse(tables.isEmpty());
     assertEquals(1, tables.size());
     TableSummary table1 = tables.get(0);
-    assertNotNull(table1.getSchema());
-    assertNotNull(table1.getTable());
     assertEquals("schema", table1.getSchema());
     assertEquals("table", table1.getTable());
     


### PR DESCRIPTION
…in Oracle.(https://cdap.atlassian.net/browse/CDAP-20199)

Set the hierarchy level to 2 to retrieve info of 2 levels(schema and tables, i.e., not including column level info)  in "Select tables and transformations" step.