### PR TITLE
CDAP-20257: Fix issue datastream assessment blocks for a long time if a non existing table name is entered

### DIFF
--- a/src/main/java/io/cdap/delta/datastream/util/Utils.java
+++ b/src/main/java/io/cdap/delta/datastream/util/Utils.java
@@ -887,6 +887,9 @@ public final class Utils {
       .abortOn(t ->
         t instanceof NotFoundException ||
         t instanceof InvalidArgumentException ||
+        t instanceof FailedPreconditionException ||
+        t instanceof AlreadyExistsException ||
+        t instanceof IllegalArgumentException ||
         t.getCause() instanceof ExecutionException && (
         // connection profile already exists
         t.getCause().getCause() instanceof AlreadyExistsException ||

--- a/src/test/java/io/cdap/delta/datastream/DatastreamTableRegistryTest.java
+++ b/src/test/java/io/cdap/delta/datastream/DatastreamTableRegistryTest.java
@@ -16,6 +16,10 @@
 
 package io.cdap.delta.datastream;
 
+import com.google.api.gax.grpc.GrpcStatusCode;
+import com.google.api.gax.rpc.AlreadyExistsException;
+import com.google.api.gax.rpc.FailedPreconditionException;
+import com.google.api.gax.rpc.InvalidArgumentException;
 import com.google.cloud.datastream.v1.DatastreamClient;
 import com.google.cloud.datastream.v1.DiscoverConnectionProfileRequest;
 import com.google.cloud.datastream.v1.DiscoverConnectionProfileResponse;
@@ -24,46 +28,62 @@ import com.google.cloud.datastream.v1.OracleSchema;
 import com.google.cloud.datastream.v1.OracleTable;
 import io.cdap.delta.api.assessment.TableList;
 import io.cdap.delta.api.assessment.TableSummary;
+import io.grpc.Status;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
-public class DatastreamTableRegistryTest {
-  @Test
-  public void testListTable() throws Exception {
-    DatastreamConfig datastreamConfig = Mockito.mock(DatastreamConfig.class);
+class DatastreamTableRegistryTest {
+
+  private static final String TABLE = "table";
+  private static final String SCHEMA = "schema";
+  private static final String DATABASE = "sid";
+  private DatastreamConfig datastreamConfig;
+  private DatastreamClient datastreamClient;
+  private DatastreamTableRegistry datastreamTableRegistry;
+
+  @BeforeEach
+  public void setupTest() {
+    datastreamConfig = Mockito.mock(DatastreamConfig.class);
     Mockito.when(datastreamConfig.isUsingExistingStream()).thenReturn(false);
-    Mockito.when(datastreamConfig.getSid()).thenReturn("sid");
+    Mockito.when(datastreamConfig.getSid()).thenReturn(DATABASE);
     Mockito.when(datastreamConfig.getHost()).thenReturn("host");
     Mockito.when(datastreamConfig.getUser()).thenReturn("user");
     Mockito.when(datastreamConfig.getPassword()).thenReturn("password");
     Mockito.when(datastreamConfig.getConnectivityMethod()).thenReturn("ip-allowlisting");
 
+    datastreamClient = Mockito.mock(DatastreamClient.class);
+    datastreamTableRegistry = new DatastreamTableRegistry(datastreamConfig, datastreamClient);
+  }
+
+  @Test
+  void testListTable() throws Exception {
+
     DiscoverConnectionProfileResponse response = Mockito.mock(DiscoverConnectionProfileResponse.class);
 
     OracleTable table = Mockito.mock(OracleTable.class);
-    Mockito.when(table.getTable()).thenReturn("table");
+    Mockito.when(table.getTable()).thenReturn(TABLE);
     Mockito.when(table.getOracleColumnsCount()).thenReturn(2);
 
     OracleSchema schema = Mockito.mock(OracleSchema.class);
-    Mockito.when(schema.getSchema()).thenReturn("schema");
+    Mockito.when(schema.getSchema()).thenReturn(SCHEMA);
     Mockito.when(schema.getOracleTablesList()).thenReturn(Arrays.asList(table));
 
     OracleRdbms oracleRdbms = Mockito.mock(OracleRdbms.class);
     Mockito.when(response.getOracleRdbms()).thenReturn(oracleRdbms);
     Mockito.when(oracleRdbms.getOracleSchemasList()).thenReturn(Arrays.asList(schema));
 
-    DatastreamClient datastreamClient = Mockito.mock(DatastreamClient.class);
     Mockito.when(datastreamClient.discoverConnectionProfile(Mockito.any())).thenReturn(response);
 
-    DatastreamTableRegistry datastreamTableRegistry = new DatastreamTableRegistry(datastreamConfig, datastreamClient);
     TableList tableList = datastreamTableRegistry.listTables();
 
     assertNotNull(tableList);
@@ -71,13 +91,48 @@ public class DatastreamTableRegistryTest {
     assertNotNull(tables);
     assertEquals(1, tables.size());
     TableSummary table1 = tables.get(0);
-    assertEquals("schema", table1.getSchema());
-    assertEquals("table", table1.getTable());
+    assertEquals(SCHEMA, table1.getSchema());
+    assertEquals(TABLE, table1.getTable());
     
     //verify hierarchy depth set to 2
     ArgumentCaptor<DiscoverConnectionProfileRequest> captor = ArgumentCaptor.forClass(
       DiscoverConnectionProfileRequest.class);
     Mockito.verify(datastreamClient).discoverConnectionProfile(captor.capture());
     assertEquals(2, captor.getValue().getHierarchyDepth());
+  }
+
+  @Test
+  void testDescribeTableFailsForPermanentErrors() {
+    List<Throwable> exceptions = new ArrayList<>();
+    exceptions.add(new FailedPreconditionException("error", new Exception("error"),
+                                                   GrpcStatusCode.of(Status.Code.FAILED_PRECONDITION), false));
+    exceptions.add(new AlreadyExistsException("error", new Exception("error"),
+                                              GrpcStatusCode.of(Status.Code.ALREADY_EXISTS), false));
+    exceptions.add(new InvalidArgumentException("error", new Exception("error"),
+                                                GrpcStatusCode.of(Status.Code.INVALID_ARGUMENT), false));
+    exceptions.add(new IllegalArgumentException("error", new Exception("error")));
+
+    for (Throwable exception : exceptions) {
+      Mockito.reset(datastreamClient);
+      Mockito.when(datastreamClient.discoverConnectionProfile(Mockito.any()))
+        .thenThrow(exception);
+
+      Assertions.assertThrows(exception.getClass(),
+                              () -> datastreamTableRegistry.describeTable(DATABASE, SCHEMA, TABLE));
+
+      ArgumentCaptor<DiscoverConnectionProfileRequest> captor = ArgumentCaptor.forClass(
+        DiscoverConnectionProfileRequest.class);
+      //Verify no retries
+      Mockito.verify(datastreamClient, Mockito.times(1))
+        .discoverConnectionProfile(captor.capture());
+
+      //Verify request details
+      OracleRdbms oracleRdbmsRequest = captor.getValue().getOracleRdbms();
+      Assertions.assertEquals(1, oracleRdbmsRequest.getOracleSchemasCount());
+      OracleSchema oracleSchemasRequest = oracleRdbmsRequest.getOracleSchemas(0);
+      Assertions.assertEquals(SCHEMA, oracleSchemasRequest.getSchema());
+      Assertions.assertEquals(1, oracleSchemasRequest.getOracleTablesCount());
+      Assertions.assertEquals(TABLE, oracleSchemasRequest.getOracleTables(0).getTable());
+    }
   }
 }


### PR DESCRIPTION
In case the selected (or manually entered) table does not exist in the DB, discoverConnectionProfile Datastream API gives `FailedPreconditionException` error. Currently the retry handling does have this exception in the list of abort conditions and hence the request is retries till the max duration of 5 minutes.

The PR adds the exception to the list of abort condition and also includes a unit test for the scenario.