### PR TITLE
Removing snapshot for 6.11 release

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
 
   <groupId>io.cdap.delta</groupId>
   <artifactId>datastream-delta-plugins</artifactId>
-  <version>0.8.0-SNAPSHOT</version>
+  <version>0.8.0</version>
   <name>Datastream Delta plugins</name>
   <packaging>jar</packaging>
   <description>Datastream Delta plugins</description>
@@ -520,7 +520,7 @@
         <dependency>
           <groupId>io.cdap.tests.e2e</groupId>
           <artifactId>cdap-e2e-framework</artifactId>
-          <version>0.3.0-SNAPSHOT</version>
+          <version>0.4.0</version>
           <scope>test</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
Removing snapshot for 6.11 release